### PR TITLE
Reduce compiler warnings (by turning some off).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,9 @@ if __name__ == '__main__':
         			SQLPARSER_DIR + 'ext/node_visitor/' ],
             library_dirs = [ SQLPARSER_DIR + '/lib/' ],
             libraries = [ 'gspcollection' + ARCH, 'gspcore' + ARCH ],
-            define_macros = [ ('_CRT_SECURE_NO_WARNINGS', None), ('DONT_FIX_FRAGMENTS', None), ]
+            define_macros = [ ('_CRT_SECURE_NO_WARNINGS', None), ('DONT_FIX_FRAGMENTS', None), ],
+            extra_compile_args = ['-Wno-strict-prototypes'],
+
         )
 
         if sys.platform == 'win32' or sys.platform == 'win64':


### PR DESCRIPTION
Others could also be disabled, or even better the gsp library could be fixed, but this at least makes it a little quieter.
